### PR TITLE
feat: add broadcast and group management modules with CRUD operations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const cookieParser = require('cookie-parser')
 const path = require('path')
 const axios = require('axios')
 const v1router = require('./routes')
+const { initBroadcastScheduler } = require('../src/modules/diabeticsModule/controllers/broadcast.js')
 // CORS configuration
 app.use(
   cors({
@@ -125,8 +126,15 @@ mongoose
     useNewUrlParser: true,
     useUnifiedTopology: true,
   })
-  .then(() => {
+  .then(async () => {
     console.log('Connected to MongoDB')
+
+    // Initialize broadcast scheduler
+    
+     await initBroadcastScheduler()
+
+
+
     // Start the Express server once connected to MongoDB
     app.listen(8010, () => {
       console.log('Server started on port 8010')

--- a/src/models/diabeticsModule/broadcast.js
+++ b/src/models/diabeticsModule/broadcast.js
@@ -1,0 +1,40 @@
+const mongoose = require('mongoose');
+
+const broadcastSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true
+  },
+  recipients: {
+    type: [String],
+    required: true
+  },
+  type: {
+    type: String,
+    enum: ['text', 'template'],
+    required: true
+  },
+  text: {
+    type: String
+  },
+  templateName: {
+    type: String
+  },
+  templateParams: {
+    type: mongoose.Mixed
+  },
+  scheduledAt: {
+    type: Date,
+    required: true
+  },
+  sent: {
+    type: Boolean,
+    default: false
+  },
+  results: {
+    type: [String],
+    default: []
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Broadcast', broadcastSchema);

--- a/src/models/diabeticsModule/group.js
+++ b/src/models/diabeticsModule/group.js
@@ -1,0 +1,28 @@
+
+const mongoose = require('mongoose');
+
+
+const groupSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  description:{
+    type: String,
+    required: true
+  }
+  ,
+  patients: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Patient'
+    }
+  ],
+//   createdBy: {
+//     type: mongoose.Schema.Types.ObjectId,
+//     ref: 'user'
+//   }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Group', groupSchema);

--- a/src/modules/diabeticsModule/controllers/broadcast.js
+++ b/src/modules/diabeticsModule/controllers/broadcast.js
@@ -1,0 +1,143 @@
+const Broadcast = require('../../../models/diabeticsModule/broadcast.js');
+const Chat = require('../../../models/diabeticsModule/chat.js');
+const { sendMessage } = require('../services/whatsappService');
+
+//  Schedules or immediately sends a broadcast
+const scheduleBroadcast = (broadcast) => {
+  const delay = broadcast.scheduledAt.getTime() - Date.now();
+  if (broadcast.sent) return;
+  if (delay <= 0) {
+    executeBroadcast(broadcast);
+  } else {
+    setTimeout(() => executeBroadcast(broadcast), delay);
+  }
+};
+
+//  Executes the broadcast message send
+const executeBroadcast = async (broadcast) => {
+  try {
+    const fresh = await Broadcast.findById(broadcast._id);
+    if (!fresh || fresh.sent) return;
+
+    const results = [];
+
+    for (const to of fresh.recipients) {
+      try {
+        let waRes;
+        if (fresh.type === 'template') {
+          waRes = await sendMessage(to, null, fresh.templateName, fresh.templateParams);
+        } else {
+          waRes = await sendMessage(to, fresh.text);
+        }
+
+        const chat = await Chat.create({
+          messageId: waRes?.messages?.[0]?.id || 'unknown',
+          direction: 'outbound',
+          from: process.env.WHATSAPP_PHONE_NUMBER,
+          to,
+          text: fresh.type === 'text' ? fresh.text : null,
+          templateName: fresh.type === 'template' ? fresh.templateName : null,
+          templateParams: fresh.type === 'template' ? fresh.templateParams : null,
+          timestamp: new Date()
+        });
+
+        results.push(chat._id);
+      } catch (err) {
+        console.error(`❌ Failed to send to ${to}`, err.message);
+      }
+    }
+
+    await Broadcast.findByIdAndUpdate(fresh._id, {
+      sent: true,
+      results
+    });
+  } catch (err) {
+    console.error('Broadcast execution failed:', err.message);
+  }
+};
+
+//  On server start, reschedule unsent broadcasts
+const initBroadcastScheduler = async () => {
+  try {
+    const pending = await Broadcast.find({ sent: false });
+    pending.forEach(scheduleBroadcast);
+    console.log(`✅ Rescheduled ${pending.length} broadcasts`);
+  } catch (err) {
+    console.error('Failed to init scheduler:', err.message);
+  }
+};
+
+//  Create a new broadcast
+const createBroadcast = async (req, res, next) => {
+  try {
+    const {
+      name,
+      recipients,
+      type,
+      text,
+      templateName,
+      templateParams,
+      scheduledAt
+    } = req.body;
+
+    const scheduledTime = new Date(scheduledAt);//please send utc time in ISO format
+    if (isNaN(scheduledTime.getTime())) {
+      return res.status(400).json({ message: 'Invalid scheduledAt' });
+    }
+
+    const bc = await Broadcast.create({
+      name,
+      recipients,
+      type,
+      text: type === 'text' ? text : undefined,
+      templateName: type === 'template' ? templateName : undefined,
+      templateParams: type === 'template' ? templateParams : undefined,
+      scheduledAt: scheduledTime
+    });
+
+    scheduleBroadcast(bc);
+    res.status(201).json(bc);
+  } catch (err) {
+    next(err);
+  }
+};
+
+//  List all broadcasts
+const listBroadcasts = async (req, res, next) => {
+  try {
+    const all = await Broadcast.find().sort({ scheduledAt: -1 });
+    res.json(all);
+  } catch (err) {
+    next(err);
+  }
+};
+
+//  Get one broadcast by ID
+const getBroadcast = async (req, res, next) => {
+  try {
+    const bc = await Broadcast.findById(req.params.id);
+    if (!bc) return res.status(404).json({ message: 'Broadcast not found' });
+    res.json(bc);
+  } catch (err) {
+    next(err);
+  }
+};
+
+//  Delete a broadcast
+const deleteBroadcast = async (req, res, next) => {
+  try {
+    const bc = await Broadcast.findByIdAndDelete(req.params.id);
+    if (!bc) return res.status(404).json({ message: 'Broadcast not found' });
+    res.json({ message: 'Broadcast deleted successfully' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = {
+  createBroadcast,
+  listBroadcasts,
+  getBroadcast,
+  deleteBroadcast,
+  initBroadcastScheduler   //TODO : Call this IN app.js to reschedule broadcasts
+};

--- a/src/modules/diabeticsModule/controllers/group.js
+++ b/src/modules/diabeticsModule/controllers/group.js
@@ -1,0 +1,113 @@
+const Group = require('../../../models/diabeticsModule/group.js');
+const Patient = require('../../../models/diabeticsModule/patient');
+
+exports.createGroup = async (req, res, next) => {
+  try {
+    const { name, description, patientIds } = req.body;
+
+
+    if (!name || !description || !patientIds || !Array.isArray(patientIds)) {
+      return res.status(400).json({ message: 'Invalid input data' });
+    }
+
+    const existingPatients = await Patient.find({ _id: { $in: patientIds } });
+    if (existingPatients.length !== patientIds.length) {
+     return res.status(400).json({ error: 'Some patient IDs are invalid.' });
+    }
+    // Check if group with the same name already exists
+    const existingGroup = await Group.findOne({ name });
+    if (existingGroup) {
+      return res.status(400).json({ message: 'Group with this name already exists' });
+    }
+
+
+    
+    
+
+    const group = await Group.create({
+      name,
+      description,
+      patients: patientIds, // it will need an array of patient ids from frontend
+    //   createdBy: req.user._id
+    });
+
+
+    res.status(201).json(group);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.addPatientToGroup = async (req, res, next) => {
+  try {
+    const { groupId } = req.params;
+    const { patientIds } = req.body;
+    if (!groupId || !patientIds || !Array.isArray(patientIds) || patientIds.length === 0) {
+      return res.status(400).json({ message: 'Group ID and Patient ID are required' });
+    }
+
+
+    const group = await Group.findByIdAndUpdate(
+      groupId,
+      { $addToSet: { patients: patientIds } },
+      { new: true }
+    );
+
+    
+
+    res.json({
+      message: 'Patients added to group successfully',
+      group});
+  } catch (error) {
+    next(error);
+  }
+};
+
+
+exports.removePatientsFromGroup = async (req, res, next) => {
+  try {
+    const { groupId } = req.params;
+    const { patientIds } = req.body;
+
+    if (!groupId || !Array.isArray(patientIds) || patientIds.length === 0) {
+      return res.status(400).json({ message: 'Group ID and an array of patient IDs are required' });
+    }
+
+    const group = await Group.findByIdAndUpdate(
+      groupId,
+      { $pull: { patients: { $in: patientIds } } },
+      { new: true }
+    );
+
+    if (!group) {
+      return res.status(404).json({ message: 'Group not found' });
+    }
+    console.log(`Removed patients: ${patientIds} from group: ${groupId}`);
+
+    res.json({
+      message: 'Patients removed from group successfully',
+      group
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getGroupMembers = async (req, res, next) => {
+  try {
+
+    const group = await Group.findById(req.params.groupId).populate('patients');
+    res.json(group);
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.getAllGroups = async (req, res, next) => {
+  try {
+    const groups = await Group.find().populate('patients');
+    res.json(groups);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/modules/diabeticsModule/routes/broadcast.js
+++ b/src/modules/diabeticsModule/routes/broadcast.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const {
+ createBroadcast,
+  listBroadcasts,
+  getBroadcast,
+  deleteBroadcast,
+  initBroadcastScheduler 
+} = require('../controllers/broadcast.js');
+
+const router = express.Router();
+
+router.post('/create', createBroadcast);
+
+// List all broadcasts
+router.get('/', listBroadcasts);
+
+// Get a single broadcast
+router.get('/:id', getBroadcast);
+
+// Delete a broadcast (only if not yet sent)
+router.delete('/delete/:id', deleteBroadcast);
+
+
+module.exports = router;

--- a/src/modules/diabeticsModule/routes/group.js
+++ b/src/modules/diabeticsModule/routes/group.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+
+const groupController = require('../controllers/group.js');
+
+
+router.post('/create', groupController.createGroup);
+router.get('/all', groupController.getAllGroups);
+router.get('/:groupId', groupController.getGroupMembers);
+router.post('/:groupId/patients/add', groupController.addPatientToGroup);
+router.delete('/:groupId/patients/remove', groupController.removePatientsFromGroup);
+
+module.exports = router;

--- a/src/modules/diabeticsModule/routes/index.js
+++ b/src/modules/diabeticsModule/routes/index.js
@@ -11,5 +11,7 @@ router.use("/doctor", require("./doctor.js"));
 // router.use("/whatsapp", require("./whatsappService.js"));
 router.use("/chat", require("./chat.js"));
 router.use("/webhook", require("./webhook.js"));
+router.use("/group", require("./group.js"));
+router.use("/broadcast", require("./broadcast.js"));
 
 module.exports = router;


### PR DESCRIPTION
Broadcast Module
Model: Broadcast model stores details about scheduled messages.

Fields include: name, recipients, type (text or template), text, templateName, templateParams, scheduledAt, sent, and results.

Controller (broadcast.js):

createBroadcast: Creates a broadcast message (text/template) scheduled for a future time.

scheduleBroadcast: Schedules messages to be sent at the appropriate time using setTimeout.

executeBroadcast: Sends messages using sendMessage() (from WhatsApp service), records results in Chat, and marks broadcast as sent.

initBroadcastScheduler: Automatically re-schedules any unsent broadcasts on server restart.

listBroadcasts, getBroadcast, deleteBroadcast: CRUD utilities for broadcasts.

Routes:

POST /broadcast/create: Schedule a new broadcast.

GET /broadcast/: List all broadcasts.

GET /broadcast/:id: Get broadcast details by ID.

DELETE /broadcast/delete/:id: Delete an unsent broadcast.

 2. Group Module
Model: Group model contains:

name, description, and an array of patients (referencing Patient model).

Controller (group.js):

createGroup: Create a new group of patients.

addPatientToGroup: Add one or more patients to an existing group.

removePatientsFromGroup: Remove selected patients from a group.

getGroupMembers: Get all members of a specific group.

getAllGroups: Fetch all patient groups.

Routes:

POST /group/create

POST /group/:groupId/patients/add

DELETE /group/:groupId/patients/remove

GET /group/:groupId

GET /group/all

 Backend Integration
 app.js is updated to call initBroadcastScheduler() after MongoDB connection, ensuring scheduled messages persist through restarts.

🧱 routes/index.js now imports and uses /group and /broadcast route